### PR TITLE
Feature/services polish

### DIFF
--- a/index.css
+++ b/index.css
@@ -316,6 +316,7 @@ svg {
 
 .services-content {
   max-width: 80%;
+  z-index: 6;
 }
 
 @media only screen and (min-width: 1000px) {
@@ -386,7 +387,10 @@ svg {
   position: relative;
 }
 
-@media screen and (max-height: 700px) {
+@media screen and (max-width: 450px) {
+.services-tabbing .tabs {
+  max-width: 450px;
+}
   .services {
     padding-bottom: 25px;
   }
@@ -574,12 +578,12 @@ svg.services-background-top {
 }
 
 
-@media only screen and (max-height: 1025px) {
+@media only screen and (max-width: 780px) {
   .contact .row {
     margin-top: 160px;
   }
 }
-@media only screen and (max-height: 800px) {
+@media only screen and (max-width: 400px) {
   .contact .row {
     padding-bottom: 20px;
     margin-bottom: 0;
@@ -597,6 +601,11 @@ svg.services-background-top {
   justify-content: flex-end;
   height: 100%;
   position: absolute !important;
+}
+
+.contact .btn {
+  margin-top: 5px;
+  float: right;
 }
 
 /*

--- a/index.css
+++ b/index.css
@@ -316,7 +316,7 @@ svg {
 
 .services-content {
   max-width: 80%;
-  z-index: 6;
+  z-index: 6; /* Resizing the window to certain sizes would cause the svg to stick over the services content */
 }
 
 @media only screen and (min-width: 1000px) {
@@ -368,8 +368,13 @@ svg {
   height: 78px;
   text-align: center;
   line-height: 78px;
+  transition: 0.4s ease-in;
 }
 
+.services-tabbing .tabs .tab a:hover {
+  background-color: #f4ce45e8;
+  color: #1c1a18;
+}
 
 .services-tabbing .tabs .tab a.active {
   color: #1c1a18;

--- a/index.css
+++ b/index.css
@@ -297,6 +297,7 @@ svg {
 
 
 /* ==================================================== services ================================================================ */
+
 .services {
   min-height: 100vh;
   width: 100%;
@@ -400,10 +401,23 @@ svg {
   color: #f4ce45e8;
 }
 
+.btn:hover {
+  background-color: #f4ce45e8;
+  color: #1c1c1c;
+}
+
+.btn {
+  background-color: #f4ce45e8;
+  color: #1c1c1c;
+}
+.btn:hover {
+  background-color: #1c1c1c;
+  color: #f4ce45e8;
+}
 .services-content .content .service .btn {
   position:absolute;
-  bottom:0.3em;
-  right:0.3em;
+  bottom:0.6em;
+  right:0.7em;
 }
 
 .services .push-bottom {


### PR DESCRIPTION
- Fixed responsive issue. Changed media to using width instead of height
- Added a z-index in edge cases where the svg shape was above services-content
- Switched the color of the button to yellow
- Added hover to buttons and tabs
- Moved the submit button on the contact to the right

- Gave up on making a transition for content part of the services. Materialize adds display: none; straight to the element. We would have to write the entire thing ourselves to get that.